### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/packages/allow-scripts/test/utils.js
+++ b/packages/allow-scripts/test/utils.js
@@ -4,7 +4,7 @@ const isWindows = platform() === 'win32'
 
 // https://github.com/nodejs/node/issues/38490
 const fixWindowsExecPath = (inPath) =>
-  '"' + inPath.replace(/"/g, '\\"') + '"'
+  '"' + inPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
 
 const portableExecPath = (inPath, debugLogging) => {
   if (!isWindows) {


### PR DESCRIPTION
Potential fix for [https://github.com/PEAC337/LavaMoat/security/code-scanning/3](https://github.com/PEAC337/LavaMoat/security/code-scanning/3)

To properly escape file paths for use in Windows command lines, we must escape **all** backslashes as well as all double quotes, and do so in a way that prevents ambiguous parse results. The standard approach is to first replace each backslash (`\`) with a double backslash (`\\`), then replace each double quote (`"`) with a backslash-escaped quote (`\"`), then wrap the whole thing in double quotes.

Alternatively, as per Microsoft's command line parsing rules, a more correct method is: All backslashes preceding a quote need to be escaped (doubled), and all double quotes escaped by a preceding backslash. The minimal universal way is to replace **every** backslash with `\\` and **every** `"` with `\"`. 

Therefore, in file `packages/allow-scripts/test/utils.js`, line 7, the body must be updated to escape both backslashes and quotes in `inPath` via a global regex. You could use:

```js
'"' + inPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
```

No new libraries are needed, as this can be done with built-in string methods. No additional methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
