### PR TITLE
Potential fix for code scanning alert no. 4: Prototype-polluting assignment

### DIFF
--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -23,6 +23,15 @@
 
 module.exports = endowmentsToolkit
 
+// Utility to prevent prototype pollution
+function isSafePropertyKey(key) {
+  return (
+    key !== '__proto__' &&
+    key !== 'constructor' &&
+    key !== 'prototype'
+  )
+}
+
 // Exports for testing
 module.exports._test = { instrumentDynamicValueAtPath }
 
@@ -711,6 +720,9 @@ function instrumentDynamicValueAtPath(pathParts, sourceRef, targetRef) {
   for (let depth = 0; depth < pathParts.length - 1; depth++) {
     currentPath = extendPath(currentPath, pathParts[depth])
     const nextPart = pathParts[depth]
+    if (!isSafePropertyKey(nextPart)) {
+      throw new Error(`Prototype-polluting key "${nextPart}" is not allowed in endowment paths.`)
+    }
     if (Reflect.getOwnPropertyDescriptor(currentTarget, nextPart)?.get) {
       // We could silently ignore this, but it could introduce a false sense of security in the policy file
       throw Error(


### PR DESCRIPTION
Potential fix for [https://github.com/PEAC337/LavaMoat/security/code-scanning/4](https://github.com/PEAC337/LavaMoat/security/code-scanning/4)

The best general solution is to **prevent dangerous property names** such as `"__proto__"`, `"constructor"`, or `"prototype"` from being used as keys when creating or manipulating objects with dynamic property names, particularly when creating property chains as here. To preserve all intended functionality, we can introduce a function to *validate* each path segment before assignment. Any path part matching those dangerous names should be rejected, either by throwing an error or skipping the property setting.

**Where to apply:**  
- In `instrumentDynamicValueAtPath`, before assigning to `currentTarget[nextPart] = {}` (and generally before any assignment with a potentially-tainted property name), validate that `nextPart` is not `"__proto__"`, `"constructor"`, or `"prototype"`.
- Likewise, in any similar dynamic assignment context.
  
**What to add:**  
- A local function like `isSafePropertyKey` near the top of the file or within the module to check property key safety.
- Each place where a user-controlled key is about to be used as a property key should perform this check and throw if unsafe.
- No external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
